### PR TITLE
feat(default): smartparens: add block comment delimiters for odin

### DIFF
--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -138,6 +138,12 @@
                    :unless '(sp-point-before-word-p sp-point-before-same-p)
                    :actions '(insert) :post-handlers '(("| " "SPC")))
 
+    ;; Block comment autopairs for Odin modes
+    (sp-local-pair '(odin-mode odin-ts-mode)
+                   "/*" "*/"
+                   :post-handlers '(("| " "SPC")
+                                    ("* ||\n[i]" "RET")))
+
     ;; Disable electric keys in C modes because it interferes with smartparens
     ;; and custom bindings. We'll do it ourselves (mostly).
     (after! cc-mode


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

Currently, smartparens is not configured to automatically insert block comment closing delimiters for odin. They are the same as the ones for C (`/**/`), so i copied the logic from the [smartparens repo](https://github.com/Fuco1/smartparens/blob/82d2cf084a19b0c2c3812e0550721f8a61996056/smartparens-c.el#L50-L51)

-----

- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
