### PR TITLE
module: add :lang scad

### DIFF
--- a/modules/lang/scad/README.org
+++ b/modules/lang/scad/README.org
@@ -1,0 +1,105 @@
+#+title:    :lang scad
+#+subtitle: 3D CAD modeling for nerds
+#+created:  June 10, 2026
+#+since:    2.2.0
+
+* Description :unfold:
+This module adds [[https://openscad.org/][OpenSCAD]] support to Doom Emacs.
+
+- Syntax highlighting (scad-mode or scad-ts-mode with tree-sitter)
+- Preview rendered models (~scad-preview~)
+- Export to STL, SVG, PNG, etc. (~scad-export~)
+- Flymake integration for inline error/warning display
+- Code completion via LSP (requires ~openscad-lsp~)
+- Org-babel support for literate OpenSCAD
+- Tree-sitter integration for superior indentation and highlighting
+
+** Maintainers
+- [[doom-user:][You?]]
+
+[[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+- +lsp ::
+  Enable LSP integration via ~openscad-lsp~. Works with both [[doom-package:lsp-mode]]
+  and [[doom-package:eglot]]. Requires [[doom-module::tools lsp]] and the
+  ~openscad-lsp~ executable in your ~$PATH~.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting, indentation, and
+  structural text editing. Requires Emacs 29.1+ and [[doom-module::tools tree-sitter]].
+
+** Packages
+- [[doom-package:scad-mode]]
+- [[doom-package:scad-ts-mode]] if [[doom-module:+tree-sitter]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+/This module does not have a changelog yet./
+
+* Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+This module requires OpenSCAD (~openscad~ CLI) for preview and export functionality.
+Pre-built binaries are available from [[https://openscad.org/downloads.html]].
+
+For LSP support, enable the [[doom-module:+lsp]] flag and the [[doom-module::tools lsp]]
+module, then install ~openscad-lsp~ (see [[https://github.com/Leathong/openscad-LSP]]) and
+ensure it is in your ~$PATH~.
+
+* TODO Usage
+#+begin_quote
+󱌣 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+#+end_quote
+
+When [[doom-module:+lsp]] is enabled, the preview buffer is set to Emacs state
+in evil to ensure camera controls work correctly.
+
+** Org Babel
+This module registers ~scad~ as an org-babel language. Use it in your org
+documents with ~#+begin_src scad~ ... ~#+end_src~. Results default to a file
+output (:results file) and code is exported (:exports code). When
+[[doom-module:+tree-sitter]] is active, source blocks are edited in
+~scad-ts-mode~.
+
+** Keybinds
+
+*** Scad mode
+| Binding             | Description              |
+|---------------------+--------------------------|
+| [[kbd:][<localleader> e]] | ~scad-export~            |
+| [[kbd:][<localleader> o]] | ~scad-open~             |
+| [[kbd:][<localleader> p]] | ~scad-preview~          |
+| [[kbd:][C-c C-c]]         | ~scad-preview~          |
+| [[kbd:][C-c C-o]]         | ~scad-open~             |
+| [[kbd:][C-c C-e]]         | ~scad-export~           |
+
+*** Preview mode
+| Binding             | Description              |
+|---------------------+--------------------------|
+| [[kbd:][[]]                | Increase distance        |
+| [[kbd:][]]]                | Decrease distance        |
+| [[kbd:][p]]                | Toggle projection        |
+| [[kbd:][h]] / [[kbd:][l]]  | Translate X axis         |
+| [[kbd:][j]] / [[kbd:][k]]  | Translate Y axis         |
+| [[kbd:][n]] / [[kbd:][m]]  | Translate Z axis         |
+| [[kbd:][H]] / [[kbd:][L]]  | Rotate X axis            |
+| [[kbd:][J]] / [[kbd:][K]]  | Rotate Y axis            |
+| [[kbd:][N]] / [[kbd:][M]]  | Rotate Z axis            |
+
+* TODO Configuration
+#+begin_quote
+󱌣 /This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+#+end_quote
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/lang/scad/config.el
+++ b/modules/lang/scad/config.el
@@ -1,0 +1,59 @@
+;;; lang/scad/config.el -*- lexical-binding: t; -*-
+
+(setq org-babel-default-header-args:scad
+  '((:results . "file")
+    (:exports . "code")))
+
+(when (and (modulep! +lsp) (modulep! :tools lsp +eglot))
+  (after! eglot
+    (add-to-list 'eglot-server-programs
+                 '(scad-mode . ("openscad-lsp" "--stdio")))
+    (add-to-list 'eglot-server-programs
+                 '(scad-ts-mode . ("openscad-lsp" "--stdio")))))
+
+
+(defun +scad-common-config (mode)
+  (when (modulep! +lsp)
+    (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append))
+  (map! :localleader
+        :map ,(intern (format "%s-map" mode))
+        :desc "Export"  "e" #'scad-export
+        :desc "Open"    "o" #'scad-open
+        :desc "Preview" "p" #'scad-preview))
+
+
+(use-package! scad-mode
+  :defer t
+  :init
+  (when (modulep! +tree-sitter)
+    (after! org-src
+      (add-to-list 'org-src-lang-modes '("scad" . scad-ts-mode))))
+  :config
+  (+scad-common-config 'scad-mode)
+  (add-to-list 'evil-emacs-state-modes 'scad-preview-mode)
+  (map! :map scad-preview-mode-map
+    :desc "Distance+"          "[" #'scad-preview-distance+
+    :desc "Distance-"          "]" #'scad-preview-distance-
+    :desc "Toggle Projection"  "p" #'scad-preview-projection
+    :desc "Translate x-"       "h" #'scad-preview-translate-x-
+    :desc "Translate x+"       "l" #'scad-preview-translate-x+
+    :desc "Translate y-"       "j" #'scad-preview-translate-y-
+    :desc "Translate y+"       "k" #'scad-preview-translate-y+
+    :desc "Translate z-"       "n" #'scad-preview-translate-z-
+    :desc "Translate z+"       "m" #'scad-preview-translate-z+
+    :desc "Rotate x-"          "H" #'scad-preview-rotate-x-
+    :desc "Rotate x+"          "L" #'scad-preview-rotate-x+
+    :desc "Rotate y-"          "J" #'scad-preview-rotate-y-
+    :desc "Rotate y+"          "K" #'scad-preview-rotate-y+
+    :desc "Rotate z-"          "N" #'scad-preview-rotate-z-
+    :desc "Rotate z+"          "M" #'scad-preview-rotate-z+))
+
+
+(use-package! scad-ts-mode
+  :when (modulep! +tree-sitter)
+  :defer t
+  :init
+  (set-tree-sitter! 'scad-mode 'scad-ts-mode
+    '((openscad :url "https://github.com/openscad/tree-sitter-openscad")))
+  :config
+  (+scad-common-config 'scad-ts-mode))

--- a/modules/lang/scad/doctor.el
+++ b/modules/lang/scad/doctor.el
@@ -1,0 +1,17 @@
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
+;;; lang/scad/doctor.el
+
+(assert! (or (modulep! -lsp)
+             (modulep! :tools lsp))
+         "This module requires (:tools lsp)")
+
+(assert! (or (modulep! -tree-sitter)
+             (modulep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
+(unless (executable-find "openscad")
+  (warn! "Couldn't find openscad binary"))
+
+(when (modulep! +lsp)
+  (unless (executable-find "openscad-lsp")
+    (warn! "Couldn't find openscad-lsp binary. Install from https://github.com/Leathong/openscad-LSP")))

--- a/modules/lang/scad/packages.el
+++ b/modules/lang/scad/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/scad/packages.el
+
+(package! scad-mode :pin "8798dca")
+
+(when (and (modulep! +tree-sitter) (treesit-available-p))
+  (package! scad-ts-mode :pin "9a61e0a"))


### PR DESCRIPTION
Adds a new lang module for OpenSCAD!

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [X] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [X] This PR contains AI-generated work.
- [X] Any relevant issues or PRs have been linked to.
- [X] This a draft PR; I need more time to finish it.

This is draft insofar that I need a bit to figure out how to test it with the new split modules structure (and with [nix-doom-emacs-unstraightened](https://github.com/marienz/nix-doom-emacs-unstraightened), yikes!)

AI notice: I used an LLM to flesh-out the README. Seems to read ok although I'm gonna edit it down a bit I think.