### PR TITLE
fix(literate): add doom core to async tangle load path

### DIFF
--- a/modules/config/literate/autoload.el
+++ b/modules/config/literate/autoload.el
@@ -81,6 +81,7 @@
                            (erase-buffer)
                            (current-buffer))
                          "emacs" "--batch"
+                         "-L" doom-core-dir
                          "-L" (file-name-directory (locate-library "org"))
                          "--load" (doom-path doom-core-dir "doom")
                          "--load" (doom-path doom-core-dir "lib/print")


### PR DESCRIPTION
## Summary

Add Doom's core lisp directory to the load path of the async literate config tangle subprocess before loading `doom.el`.

## Why

`+literate-tangle--async` starts a fresh batch Emacs process with only Org's directory added via `-L`, then loads Doom core directly:

```elisp
"-L" (file-name-directory (locate-library "org"))
"--load" (doom-path doom-core-dir "doom")
```

But `doom.el` immediately requires core libraries such as `doom-compat` from the same directory:

```elisp
(require 'doom-compat)
```

Because `doom-core-dir` is not in the subprocess `load-path`, the async tangle can fail with:

```text
Cannot open load file: No such file or directory, doom-compat
```

Adding `"-L" doom-core-dir` mirrors the direct load target and lets those core `require`s resolve.

## Verification

Reproduced the failure without the added load-path entry:

```text
emacs -q --no-site-file --batch -L <org-dir> \
  --load ~/.config/emacs/lisp/doom \
  --load ~/.config/emacs/lisp/lib/print \
  --eval '(princ "unexpected-ok\n")'

rc=255
Cannot open load file: No such file or directory, doom-compat
```

Verified the fixed command succeeds when Doom core is added to `load-path`:

```text
emacs -q --no-site-file --batch -L ~/.config/emacs/lisp -L <org-dir> \
  --load ~/.config/emacs/lisp/doom \
  --load ~/.config/emacs/lisp/lib/print \
  --eval '(princ (if (featurep '\''doom) "doom-load-ok\n" "doom-load-missing\n"))'

rc=0
doom-load-ok
```

Also verified the live async tangle path after applying the patch:

```text
(+literate-tangle--async)
=> Tangled 45 code blocks from config.org
=> ✓ Done tangling 2 file(s)!
```
