### PR TITLE
bump: evil-collection

### DIFF
--- a/modules/editor/evil/packages.el
+++ b/modules/editor/evil/packages.el
@@ -38,4 +38,4 @@
     (package! neotree)
     (autoload 'neotree-make-executor "neotree" nil nil 'macro))
 
-  (package! evil-collection :pin "673b38022b8bb36185b6d54aff3f444335a032fb"))
+  (package! evil-collection :pin "d561a7a5b699f82109de01c14050d37bda165502"))


### PR DESCRIPTION
When evil-collection made comint respect
`evil-collection-repl-submit-state`, this also rebound RET in ielm (which derives from comint) from `ielm-return` to `comint-send-input`, making it difficult to use.

Upstream fixed this (https://github.com/emacs-evil/evil-collection/commit/89fbd2264f960e75a547549dbbc8ec5322ec8dfc), but initially missed graphical frames (`<return>` versus RET): the fix for that is the commit after the one Doom is pinned to.

Fix by bumping evil-collection to that commit (there are a few more recent commits but they are not bugfixes, can wait for the next regular bump).

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it generally means we like the idea, but
     some more work must be done before it is merge ready.
   - If you decide to close your PR, please let us know why you did so.

-->
