### PR TITLE
tweak(eval): focus repl popup window when toggled

### DIFF
--- a/modules/tools/eval/config.el
+++ b/modules/tools/eval/config.el
@@ -48,7 +48,9 @@ buffer rather than an overlay on the line at point or the minibuffer."
              (set-process-query-on-exit-flag process nil)
              (kill-process process)
              (kill-buffer buf))))
-  :size 0.25 :quit nil)
+  :size 0.25
+  :quit nil
+  :select t)
 
 
 (after! quickrun


### PR DESCRIPTION
When a REPL popup window is hidden and restored via `+popup/toggle', focus is not automatically moved back to the REPL window.

If this is the intended behavior, and +popup/other is the preferred way to switch focus to a restored REPL popup, then this PR can be closed. :)

-----
- [ ] I searched the issue tracker and this hasn't been PRed before.
- [ ] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.