### PR TITLE
fix!(evil): stop evil-collection-eglot-setup overriding key bindings

### DIFF
--- a/modules/editor/evil/config.el
+++ b/modules/editor/evil/config.el
@@ -261,6 +261,7 @@ directives. By default, this only recognizes C directives."
   (defvar +evil-collection-disabled-list
     '(anaconda-mode
       company
+      eglot
       elisp-mode
       ert
       lispy)
@@ -578,11 +579,7 @@ don't offer any/enough real value to users.")
        (:after elfeed
         :map elfeed-search-mode-map
         :n "gr" #'elfeed-search-update--force
-        :n "gR" #'elfeed-search-fetch)
-       (:after eglot
-        :map eglot-mode-map
-        :nv "gd" #'+lookup/definition
-        :nv "gD" #'+lookup/references))
+        :n "gR" #'elfeed-search-fetch))
 
       ;; custom evil keybinds
       :nv "zn"    #'+evil:narrow-buffer


### PR DESCRIPTION
`evil-collection-eglot-setup` overrides `gd` `gD`, https://github.com/doomemacs/modules/commit/71f04ab3947811da618bc25de1eda692e7fc0078 fixed this but missed some edge cases. For example:

1. Open any file not using eglot
2. Open a file using eglot
3. `evil-collection-eglot-setup` got executed after the `:after eglot`

After reading the [evil-collection-eglot.el](https://github.com/emacs-evil/evil-collection/blob/94e317cedf97a2fc2d6d67e6f0260c8101ac8d00/modes/eglot/evil-collection-eglot.el) I think it's fine to just disable it, the only user-facing change is the removal of 'g5', I've added the workaround to commit msg. (Or maybe I should put it back? Is it a "Wrapping keybinds in conditional checks"?)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
