### PR TITLE
fix(vertico): embark-file-map entry clobbering

### DIFF
--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -306,7 +306,7 @@ orderless."
     "u" #'doom/help-package-homepage)
   (setf (alist-get 'package embark-keymap-alist) #'+vertico-embark-doom-package-map)
   (map! (:map embark-file-map
-         :desc "Open target with sudo"         "s"   #'doom/sudo-find-file
+         :desc "Open target with sudo"         "S"   #'doom/sudo-find-file
          (:when (modulep! :tools magit)
            :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (modulep! :ui workspaces)


### PR DESCRIPTION
On its `embark-file-map`, **embark** ships a map from `"s"` to `#'make-symbolic-link`, which gets clobbered by `#'doom/sudo-find-file'`

To fix this, I’ve just mapped the sudo thingy to (upper case) `"S"`, which does not conflict with the embark-shipped `embark-file-map`, and follows the convention of doing `sudo` things with upper-case letters, to signify that extra precaution must be taken¹.

Ref: https://github.com/orgs/doomemacs/discussions/104

¹: With great `sudo` comes great responsibility.

P.S: I think this is the first time I’ve made a 1-bit PR… ;-P

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to (provided link to a discussion).
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
