### PR TITLE
fix(ibuffer): give vc-status an explicit max width

### DIFF
--- a/modules/emacs/ibuffer/config.el
+++ b/modules/emacs/ibuffer/config.el
@@ -18,7 +18,7 @@
                 " " (size 9 -1 :right)
                 " " (mode 16 16 :left :elide)
                 ,@(when (require 'ibuffer-vc nil t)
-                    '(" " (vc-status 12 :left)))
+                    '(" " (vc-status 12 12 :left)))
                 " " filename-and-process)
           (mark " " (name 16 -1) " " filename)))
 


### PR DESCRIPTION
Doom's +icons ibuffer format was specifying the ibuffer-vc column as:

  (vc-status 12 :left)

That looks like a minimum width plus an alignment, but Emacs 30.2's Ibuffer
format entries are parsed positionally as:

  (COLUMN MIN MAX ALIGN ELIDE)

As a result, Emacs interprets the old form as MIN = 12, MAX = :left, and ALIGN
falls back to :left.  When ibuffer-vc returns a non-empty VC status whose width
is large enough to exercise the max-width path, the compiled Ibuffer formatter
compares the status width with MAX and signals:

  wrong-type-argument number-or-marker-p, :left

This breaks redisplay/insertion of Ibuffer lines on GNU Emacs 30.2.

Spell out the max width explicitly so the alignment keyword stays in the ALIGN
slot:

  (vc-status 12 12 :left)

This preserves the intended 12-column left-aligned VC status display while
matching the format shape expected by Ibuffer.