### PR TITLE
module: add :term ghostel

### DIFF
--- a/modules/term/ghostel/README.org
+++ b/modules/term/ghostel/README.org
@@ -1,0 +1,92 @@
+#+title:    :term ghostel
+#+subtitle: A terminal emulator powered by libghostty-vt
+#+created:  June 24, 2026
+#+since:    26.06.0
+
+* Description :unfold:
+This module provides support for [[https://github.com/dakra/ghostel][ghostel]], an Emacs terminal emulator powered
+by =libghostty-vt=.
+
+#+begin_quote
+ 💡 [[doom-package:ghostel]] is a modern alternative to [[doom-module::term vterm][:term vterm]], with support
+    for synchronized output, the Kitty keyboard and graphics protocols, OSC 8
+    hyperlinks, and true color. Like vterm, it requires extra steps to set up.
+#+end_quote
+
+** Maintainers
+[[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+- +evil ::
+  Enable [[https://github.com/dakra/ghostel/tree/main/extensions/evil-ghostel][evil-ghostel]], an evil-mode integration for ghostel.
+- +compilation-mode ::
+  Globally enable =ghostel-compile-global-mode= so that =compile=,
+  =recompile=, and =project-compile= run in a ghostel buffer with a real
+  TTY (true color, progress bars, curses tools).
+- +comint-mode ::
+  Globally enable =ghostel-comint-global-mode= so every comint-derived
+  buffer (=M-x shell=, REPLs, etc.) renders process output through
+  libghostty-vt's VT parser.
+- +eshell ::
+  Enable =ghostel-eshell-visual-command-mode= so eshell visual commands
+  (=vim=, =htop=, =less=, etc. as defined by =eshell-visual-commands=)
+  run in a ghostel buffer instead of falling back to the built-in
+  =term-mode=. Requires the [[doom-module::term eshell]] module to be enabled.
+
+** Packages
+- [[doom-package:ghostel]]
+- if [[doom-module:+evil]]
+  - [[doom-package:evil-ghostel]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+# This section will be machine generated. Don't edit it by hand.
+/This module does not have a changelog yet./
+
+* Installation
+[[id:01cffea4-3329-485f-9569-fc1c2a5e92fc][Enable this module in your ~doomdir~]].
+
+Prerequisites:
++ Emacs with dynamic module support (i.e. compiled with the
+  =--with-modules= option).
++ MacOS, Linux, or FreeBSD on =aarch64= or =x86_64=.
++ [[https://ziglang.org/][Zig]] 0.15 (if you want to compile the native module yourself).
+
+** Dynamic Module support
+To check if your build of Emacs has dynamic module support, run ~$ doom info~ in
+the shell and look for ~MODULES~ next to "features". If it isn't, you'll need to
+find another source to install Emacs from or recompile it with the appropriate
+build options.
+
+Alternatively, look for ~--with-modules~ in ~system-configuration-options~ ([[kbd:][SPC h v
+system-configuration-options]]).
+
+Follow [[id:9570ba6a-50cc-4c46-a832-fb90192288af][our installation guide]] to ensure your build of Emacs includes dynamic
+module support.
+
+** Native module
+ghostel ships a native dynamic module written in Zig. The first time you run
+=M-x ghostel=, it offers to download a pre-built binary for your platform
+automatically. Pre-built binaries are available for
+=aarch64-macos=, =x86_64-macos=, =x86_64-linux=, =aarch64-linux=, and
+=x86_64-freebsd=.
+
+Auto-install behavior is controlled by =ghostel-module-auto-install= (default
+=ask=); set it to =download=, =compile=, or =nil= to change the prompt.
+
+** Compiling the module from source
+/This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+
+* TODO Usage
+/This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+
+* TODO Configuration
+/This module's configuration documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]

--- a/modules/term/ghostel/autoload.el
+++ b/modules/term/ghostel/autoload.el
@@ -1,0 +1,1 @@
+;;; term/ghostel/autoload.el -*- lexical-binding: t; -*-

--- a/modules/term/ghostel/config.el
+++ b/modules/term/ghostel/config.el
@@ -1,0 +1,30 @@
+;;; term/ghostel/config.el -*- lexical-binding: t; -*-
+
+(use-package! ghostel
+  :when (bound-and-true-p module-file-suffix) ; requires dynamic-modules support
+  :commands ghostel-mode
+  :hook ((ghostel-mode . mode-line-invisible-mode) ; modeline serves no purpose in a terminal
+         (ghostel-mode . doom-disable-line-numbers-h))
+  :config
+  (set-popup-rule! "^\\*ghostel" :size 0.25 :vslot -4 :select t :quit nil :ttl 0)
+
+  (setq-hook! 'ghostel-mode-hook
+    ;; Don't prompt about dying processes when killing ghostel
+    confirm-kill-processes nil
+    ;; Prevent premature horizontal scrolling
+    hscroll-margin 0)
+
+  (when (modulep! +compilation-mode)
+    (ghostel-compile-global-mode +1))
+
+  (when (modulep! +comint-mode)
+    (ghostel-comint-global-mode +1))
+
+  (when (and (modulep! +eshell)
+             (modulep! :term eshell))
+    (add-hook 'eshell-load-hook #'ghostel-eshell-visual-command-mode)))
+
+(use-package! evil-ghostel
+  :when (and (modulep! +evil) (modulep! :editor evil))
+  :after (ghostel evil)
+  :hook (ghostel-mode . evil-ghostel-mode))

--- a/modules/term/ghostel/doctor.el
+++ b/modules/term/ghostel/doctor.el
@@ -1,0 +1,10 @@
+;;; term/ghostel/doctor.el -*- lexical-binding: t; -*-
+
+(unless (fboundp 'module-load)
+  (warn! "Your emacs wasn't built with dynamic modules support. The ghostel module won't load"))
+
+(unless (executable-find "zig")
+  (warn! "Couldn't find zig. Pre-built binaries cover most platforms; only needed if you want to compile the ghostel module from source via M-x ghostel-module-compile"))
+
+(when (and (modulep! +evil) (not (modulep! :editor evil)))
+  (warn! "+evil flag is enabled, but the :editor evil module isn't. evil-ghostel won't be loaded."))

--- a/modules/term/ghostel/packages.el
+++ b/modules/term/ghostel/packages.el
@@ -1,0 +1,12 @@
+;; -*- no-byte-compile: t; -*-
+;;; term/ghostel/packages.el
+
+(package! ghostel
+  :recipe (:host github :repo "dakra/ghostel")
+  :pin "b6d7b37353572bf92d04c8de5abced3ef68a0304")
+
+(when (and (modulep! +evil) (modulep! :editor evil))
+  (package! evil-ghostel
+    :recipe (:host github :repo "dakra/ghostel"
+             :files ("extensions/evil-ghostel/*.el"))
+    :pin "b6d7b37353572bf92d04c8de5abced3ef68a0304"))


### PR DESCRIPTION
As discussed in https://github.com/orgs/doomemacs/discussions/116

Add a new `term` module for `ghostel`: https://github.com/dakra/ghostel

This module is heavily based in the existing `vterm` module in terms of coding style. No autoloads for poups or keybindings present for now.

Added flags to enable some of the `ghostel` modes that users may want, such as using it for compilation buffers, comint buffers, and eshell handoff to visual commands.

> [!NOTE]
> 1. I have purposefully ignored autoloads for popup terminals etc, as well as default keybindings to minimise the review burden, but happy to discuss and add them :)
> 1. The current `pin` for the packages is the latest version: https://github.com/dakra/ghostel/releases/tag/v0.38.0
> 1. Because the README is based off `vterm`, I just copied the `[[id:...]]` blocks and other thuings, but my org-mode skills are not that great so I may have fudged something.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
