### PR TITLE
fix(odin): add -stdin flag to odinfmt

### DIFF
--- a/modules/lang/odin/config.el
+++ b/modules/lang/odin/config.el
@@ -19,7 +19,7 @@ Can be overridden per-project via .dir-locals.el."
 ;;; Packages
 
 (defun +odin-common-config (mode)
-  (set-formatter! 'odinfmt '("odinfmt") :modes (list mode))
+  (set-formatter! 'odinfmt '("odinfmt" "-stdin") :modes (list mode))
   (when (modulep! +lsp)
     (add-hook (intern (format "%s-local-vars-hook" mode)) #'lsp! 'append))
   (map! :map ,(intern (format "%s-map" mode))


### PR DESCRIPTION
fix(lang/odin): pass -stdin to odinfmt

The current bare invocation of the odin lang formatter  `'("odinfmt")'` fails and exits 1, so format-on-save never applies due to the buffer being passed through stdin and odinfmt not be able to read it.

Add the -stdin flag to match odinfmt's documented setup and resolve the exit 1 from odinfmt

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.