### PR TITLE
fix(mu4e): mu4e-marks: restore delete operation

### DIFF
--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -627,20 +627,7 @@ See `+mu4e-msg-gmail-p' and `mu4e-sent-messages-behavior'.")
 
     (defvar +mu4e--last-invalid-gmail-action 0)
 
-    (setf (alist-get 'delete mu4e-marks)
-          (list
-           :char '("D" . "✘")
-           :prompt "Delete"
-           :show-target (lambda (_target) "delete")
-           :action (lambda (docid msg target)
-                     (if (+mu4e-msg-gmail-p msg)
-                         (progn (message "The delete operation is invalid for Gmail accounts. Trashing instead.")
-                                (+mu4e--mark-seen docid msg target)
-                                (when (< 2 (- (float-time) +mu4e--last-invalid-gmail-action))
-                                  (sit-for 1))
-                                (setq +mu4e--last-invalid-gmail-action (float-time)))
-                       (mu4e--server-remove docid))))
-          (alist-get 'trash mu4e-marks)
+    (setf (alist-get 'trash mu4e-marks)
           (list :char '("d" . "▼")
                 :prompt "dtrash"
                 :dyn-target (lambda (_target msg) (mu4e-get-trash-folder msg))


### PR DESCRIPTION
Gmail has an option to delete email if it is deleted on an IMAP client.

Gmail has an option to delete email if it is deleted on an IMAP client.
I've deleted changes to delete in mu4e-marks 

BREAKING CHANGE: email is now properly being deleted for Gmail when it was trashed before
-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.