### PR TITLE
Replace browse-at-remote with git-link

### DIFF
--- a/modules/config/default/+emacs-bindings.el
+++ b/modules/config/default/+emacs-bindings.el
@@ -346,8 +346,8 @@
       ;;; <leader> v --- versioning
       (:prefix-map ("v" . "versioning")
        :desc "Git revert file"             "R"   #'vc-revert
-       :desc "Kill link to remote"         "y"   #'+vc/browse-at-remote-kill
-       :desc "Kill link to homepage"       "Y"   #'+vc/browse-at-remote-kill-homepage
+       :desc "Kill link to remote"         "y"   #'+vc/git-link-kill
+       :desc "Kill link to homepage"       "Y"   #'+vc/git-link-kill-homepage
        (:when (modulep! :ui vc-gutter)
         :desc "Git revert hunk"            "r"   #'+vc-gutter/revert-hunk
         :desc "Git stage hunk"             "s"   #'+vc-gutter/stage-hunk
@@ -374,8 +374,8 @@
          :desc "Find issue"                "i"   #'forge-visit-issue
          :desc "Find pull request"         "p"   #'forge-visit-pullreq)
         (:prefix ("o" . "open in browser")
-         :desc "Browse file or region"     "."   #'+vc/browse-at-remote
-         :desc "Browse homepage"           "h"   #'+vc/browse-at-remote-homepage
+         :desc "Browse file or region"     "."   #'+vc/git-link
+         :desc "Browse homepage"           "h"   #'+vc/git-link-homepage
          :desc "Browse remote"             "r"   #'forge-browse-remote
          :desc "Browse commit"             "c"   #'forge-browse-commit
          :desc "Browse an issue"           "i"   #'forge-browse-issue

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -522,8 +522,8 @@
       ;;; <leader> g --- git/version control
       (:prefix-map ("g" . "git")
        :desc "Revert file"                 "R"   #'vc-revert
-       :desc "Copy link to remote"         "y"   #'+vc/browse-at-remote-kill
-       :desc "Copy link to homepage"       "Y"   #'+vc/browse-at-remote-kill-homepage
+       :desc "Copy link to remote"         "y"   #'+vc/git-link-kill
+       :desc "Copy link to homepage"       "Y"   #'+vc/git-link-kill-homepage
        :desc "Git time machine"            "t"   #'git-timemachine-toggle
        (:when (modulep! :ui vc-gutter)
         :desc "Revert hunk at point"      "r"   #'+vc-gutter/save-and-revert-hunk
@@ -551,8 +551,8 @@
          :desc "Find issue"                "i"   #'forge-visit-issue
          :desc "Find pull request"         "p"   #'forge-visit-pullreq)
         (:prefix ("o" . "open in browser")
-         :desc "Browse file or region"     "o"   #'+vc/browse-at-remote
-         :desc "Browse homepage"           "h"   #'+vc/browse-at-remote-homepage
+         :desc "Browse file or region"     "o"   #'+vc/git-link
+         :desc "Browse homepage"           "h"   #'+vc/git-link-homepage
          :desc "Browse remote"             "r"   #'forge-browse-remote
          :desc "Browse commit"             "c"   #'forge-browse-commit
          :desc "Browse an issue"           "i"   #'forge-browse-issue

--- a/modules/emacs/vc/autoload/vc.el
+++ b/modules/emacs/vc/autoload/vc.el
@@ -3,69 +3,38 @@
 ;;
 ;;; Helpers
 
-(defun +vc--remote-homepage ()
-  (require 'browse-at-remote)
-  (or (let ((url (browse-at-remote--remote-ref)))
-        (plist-get (browse-at-remote--get-url-from-remote (car url)) :url))
-      (user-error "Can't find homepage for current project")))
-
-;; TODO: PR these upstream?
-;;;###autoload
-(defun browse-at-remote--format-region-url-as-codeberg (repo-url location filename &optional linestart lineend)
-  "URL formatted for codeberg."
-  (cond
-   ((and linestart lineend)
-    (format "%s/src/%s/%s#L%d-L%d" repo-url location filename linestart lineend))
-   (linestart (format "%s/src/%s/%s#L%d" repo-url location filename linestart))
-   (t (format "%s/src/%s/%s" repo-url location filename))))
-
-;;;###autoload
-(defun browse-at-remote--format-commit-url-as-codeberg (repo-url commithash)
-  "Commit URL formatted for codeberg"
-  (format "%s/src/commit/%s" repo-url commithash))
-
 
 ;;
 ;;; Commands
 
-(defvar browse-at-remote-prefer-symbolic)
 ;;;###autoload
-(defun +vc/browse-at-remote (&optional arg)
-  "Open URL to current file (and line if selection is active) in browser.
-If prefix ARG, negate the default value of `browse-at-remote-prefer-symbolic'."
-  (interactive "P")
-  (require 'browse-at-remote)
-  (let ((vc-ignore-dir-regexp locate-dominating-stop-dir-regexp)
-        (browse-at-remote-prefer-symbolic
-         (if arg
-             (not browse-at-remote-prefer-symbolic)
-           browse-at-remote-prefer-symbolic)))
-    (browse-at-remote)))
+(defun +vc/git-link ()
+  "Open URL to current file (and line if selection is active) in browser."
+  (interactive)
+  (require 'magit)
+  (if (region-active-p)
+      (browse-url (git-link (magit-get-remote) (line-number-at-pos (region-beginning) ) (line-number-at-pos (region-end))))
+    (browse-url (git-link (magit-get-remote) nil nil))))
 
 ;;;###autoload
-(defun +vc/browse-at-remote-kill (&optional arg interactive?)
-  "Copy URL to current file (and line if selection is active) to clipboard.
-If prefix ARG, negate the default value of `browse-at-remote-prefer-symbolic'."
-  (interactive (list current-prefix-arg 'interactive))
-  (require 'browse-at-remote)
-  (let ((vc-ignore-dir-regexp locate-dominating-stop-dir-regexp)
-        (browse-at-remote-prefer-symbolic
-         (if arg
-             (not browse-at-remote-prefer-symbolic)
-           browse-at-remote-prefer-symbolic)))
-    (browse-at-remote-kill)
-    (if interactive? (message "Copied to clipboard"))))
+(defun +vc/git-link-kill ()
+  "Open URL to current file (and line if selection is active) in browser."
+  (interactive)
+  (require 'magit)
+  (if (region-active-p)
+      (kill-new (git-link (magit-get-remote) (line-number-at-pos (region-beginning)) (line-number-at-pos (region-end))))
+    (kill-new (git-link (magit-get-remote) nil nil))))
 
 ;;;###autoload
-(defun +vc/browse-at-remote-homepage ()
+(defun +vc/git-link-homepage ()
   "Open homepage for current project in browser."
   (interactive)
-  (browse-url (+vc--remote-homepage)))
+  (require 'magit)
+  (browse-url (git-link-homepage (magit-get-remote))))
 
 ;;;###autoload
-(defun +vc/browse-at-remote-kill-homepage ()
+(defun +vc/git-link-kill-homepage ()
   "Copy homepage URL of current project to clipboard."
   (interactive)
-  (let ((url (+vc--remote-homepage)))
-    (kill-new url)
-    (message "Copied to clipboard: %S" url)))
+  (require 'magit)
+  (kill-new (git-link-homepage (magit-get-remote))))

--- a/modules/emacs/vc/config.el
+++ b/modules/emacs/vc/config.el
@@ -89,34 +89,6 @@
   ;; `header-line-format', which has better visibility.
   (setq git-timemachine-show-minibuffer-details t)
 
-  ;; REVIEW: PR this to `git-timemachine'
-  (defadvice! +vc-support-git-timemachine-a (fn)
-    "Allow `browse-at-remote' commands in git-timemachine buffers to open that
-file in your browser at the visited revision."
-    :around #'browse-at-remote-get-url
-    (if git-timemachine-mode
-        (let* ((start-line (and (use-region-p) (line-number-at-pos
-                                                (min (region-beginning) (region-end)))))
-               (point-end (and (use-region-p) (max (region-beginning) (region-end))))
-               (end-line (and (use-region-p) (line-number-at-pos point-end)))
-               (remote-ref (browse-at-remote--remote-ref buffer-file-name))
-               (remote (car remote-ref))
-               (ref (car git-timemachine-revision))
-               (relname
-                (file-relative-name
-                 buffer-file-name (expand-file-name (vc-git-root buffer-file-name))))
-               (target-repo (browse-at-remote--get-url-from-remote remote))
-               (remote-type (browse-at-remote--get-remote-type (plist-get target-repo :unresolved-host)))
-               (repo-url (plist-get target-repo :url))
-               (url-formatter (browse-at-remote--get-formatter 'region-url remote-type)))
-          (unless url-formatter
-            (error (format "Origin repo parsing failed: %s" repo-url)))
-          (funcall url-formatter repo-url ref relname
-                   (if start-line start-line)
-                   (when (and end-line (not (equal start-line end-line)))
-                     (if (eq (char-before point-end) ?\n) (- end-line 1) end-line))))
-      (funcall fn)))
-
   (defadvice! +vc-update-header-line-a (revision)
     "Show revision details in the header-line, instead of the minibuffer.
 
@@ -149,27 +121,3 @@ info in the `header-line-format' is a more visible indicator."
         :n "C-n" #'git-timemachine-show-next-revision
         :n "gb"  #'git-timemachine-blame
         :n "gtc" #'git-timemachine-show-commit))
-
-
-(after! browse-at-remote
-  ;; It's more sensible that the user have more options. If they want line
-  ;; numbers, users can request them by making a selection first. Otherwise
-  ;; omitting them.
-  (setq browse-at-remote-add-line-number-if-no-region-selected nil)
-  ;; Opt to produce permanent links with `browse-at-remote' by default, using
-  ;; commit hashes rather than branch names.
-  (setq browse-at-remote-prefer-symbolic nil)
-
-  ;; Expand recognition for more forges (like self-hosted gitlab.* subdomains
-  ;; and codeberg).
-  ;; REVIEW: PR these upstream?
-  (add-to-list 'browse-at-remote-remote-type-regexps '(:host "^codeberg\\.org$" :type "codeberg"))
-  (add-to-list 'browse-at-remote-remote-type-regexps '(:host "^gitlab\\." :type "gitlab") 'append)
-
-  ;; HACK: `browse-at-remote' produces urls with `nil' in them, when the repo is
-  ;;   detached. This creates broken links. I think it is more sensible to fall
-  ;;   back to master in those cases.
-  (defadvice! +vc--fallback-to-master-branch-a ()
-    "Return 'master' in detached state."
-    :after-until #'browse-at-remote--get-local-branch
-    "master"))

--- a/modules/emacs/vc/packages.el
+++ b/modules/emacs/vc/packages.el
@@ -5,7 +5,7 @@
 (package! vc-annotate :built-in t)
 (package! smerge-mode :built-in t)
 
-(package! browse-at-remote :pin "38e5ffd77493c17c821fd88f938dbf42705a5158")
+(package! git-link :pin "3870ae57408dc72ae2215b0056d6661e2c198e75")
 (package! git-timemachine
   ;; The original lives on codeberg.org; which has uptime issues.
   :recipe (:host github :repo "emacsmirror/git-timemachine")


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

  Replace the package browse-at-remote with git-link, and remove no longer needed git-timemachine config code.
  Git link opens the current buffer's revision when called.

  Additional enhancement could be made to add a keybind for git-link-dispatch (git-link's interactive menu).

  Discussion for this PR: https://github.com/orgs/doomemacs/discussions/118

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->

