### PR TITLE
fix(ghostel): use seq-remove to strip DIRENV vars, not seq-filter

### DIFF
--- a/modules/term/ghostel/config.el
+++ b/modules/term/ghostel/config.el
@@ -40,7 +40,7 @@
     (defun +ghostel-strip-direnv-initvars-h (&rest _)
       (when (getenv "DIRENV_FILE")
         (setq-local process-environment
-                    (seq-filter (fn! (string-prefix-p "DIRENV_" %))
+                    (seq-remove (fn! (string-prefix-p "DIRENV_" %))
                                 process-environment))))))
 
 


### PR DESCRIPTION
seq-filter keeps elements matching the predicate, so the previous code retains only DIRENV_* vars and discards everything else from process-environment.

seq-remove strip the matching vars and keeps the rest, which seems is the intended behaviour.

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
