### PR TITLE
module: add :lang prisma

### DIFF
--- a/modules/lang/prisma/README.org
+++ b/modules/lang/prisma/README.org
@@ -1,0 +1,71 @@
+#+title:    :lang prisma
+#+subtitle: Next-generation ORM for TypeScript & Node.js
+#+created:  July 08, 2026
+#+since:    26.04.0
+
+* Description :unfold:
+This module adds support for the [[https://www.prisma.io/][Prisma]] ORM schema language.
+
+- Syntax highlighting (via ~prisma-mode~ or tree-sitter)
+- LSP integration (via ~prisma-language-server~)
+
+** Maintainers
+/This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
+
+** Module flags
+- +lsp ::
+  Enable LSP support for ~prisma-mode~. Requires [[doom-module::tools lsp]]
+  and the npm package ~@prisma/language-server~.
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting. Requires
+  [[doom-module::tools tree-sitter]].
+
+** Packages
+- [[doom-package:prisma-mode]]
+
+** Hacks
+/No hacks documented for this module./
+
+** TODO Changelog
+/This module does not have a changelog yet./
+
+* Installation
+[[id:01cffea4-3329-45e2-a892-95a384ab2338][Enable this module in your ~doom!~ block.]]
+
+#+begin_src emacs-lisp
+(prisma +lsp)  ; or (prisma +lsp +tree-sitter)
+#+end_src
+
+This module requires the [[https://www.prisma.io/docs/getting-started/installation][Prisma CLI]] (~prisma~) for schema management.
+
+For LSP support, install ~@prisma/language-server~:
+
+#+begin_src sh
+npm install -g @prisma/language-server
+#+end_src
+
+* Usage
+#+begin_quote
+󱌣 /This module's usage documentation is incomplete./ [[doom-contrib-module:][Complete it?]]
+#+end_quote
+
+** Keybindings
+| Binding         | Description               |
+|-----------------+---------------------------|
+| [[kbd:][<localleader> f]] | ~prisma-format-buffer~    |
+
+* TODO Configuration
+#+begin_quote
+󱌣 This module has no configuration documentation yet. [[doom-contrib-module:][Write some?]]
+#+end_quote
+
+* Troubleshooting
+/There are no known problems with this module./ [[doom-report:][Report one?]]
+
+* Frequently asked questions
+/This module has no FAQs yet./ [[doom-suggest-faq:][Ask one?]]
+
+* TODO Appendix
+#+begin_quote
+󱌣 This module has no appendix yet. [[doom-contrib-module:][Write one?]]
+#+end_quote

--- a/modules/lang/prisma/config.el
+++ b/modules/lang/prisma/config.el
@@ -4,13 +4,14 @@
   :defer t
   :config
   (when (modulep! +lsp)
-    (add-hook 'prisma-mode-local-vars-hook #'lsp! 'append))
+    (require 'lsp-prisma)
+    (add-hook 'prisma-mode-local-vars-hook #'lsp! 'append)
+    (map! :localleader
+          :map prisma-mode-map
+          "f" #'lsp-format-buffer))
   (when (modulep! +tree-sitter)
     (define-derived-mode prisma-ts-mode prisma-mode "Prisma"
       "Major mode for Prisma schema files, powered by tree-sitter.")
     (set-tree-sitter! 'prisma-mode 'prisma-ts-mode
       '((prisma :url "https://github.com/victorhqc/tree-sitter-prisma"
-                :rev "v1.6.0"))))
-  (map! :localleader
-        :map prisma-mode-map
-        "f" #'lsp-format-buffer))
+                :rev "v1.6.0")))))

--- a/modules/lang/prisma/config.el
+++ b/modules/lang/prisma/config.el
@@ -1,0 +1,14 @@
+;;; lang/prisma/config.el -*- lexical-binding: t; -*-
+
+(use-package! prisma-mode
+  :defer t
+  :config
+  (when (modulep! +lsp)
+    (add-hook 'prisma-mode-local-vars-hook #'lsp! 'append))
+  (when (modulep! +tree-sitter)
+    (set-tree-sitter! 'prisma-mode
+      '((prisma :url "https://github.com/victorhqc/tree-sitter-prisma"
+                :rev "v1.6.0"))))
+  (map! :localleader
+        :map prisma-mode-map
+        "f" #'prisma-format-buffer))

--- a/modules/lang/prisma/config.el
+++ b/modules/lang/prisma/config.el
@@ -6,9 +6,11 @@
   (when (modulep! +lsp)
     (add-hook 'prisma-mode-local-vars-hook #'lsp! 'append))
   (when (modulep! +tree-sitter)
-    (set-tree-sitter! 'prisma-mode
+    (define-derived-mode prisma-ts-mode prisma-mode "Prisma"
+      "Major mode for Prisma schema files, powered by tree-sitter.")
+    (set-tree-sitter! 'prisma-mode 'prisma-ts-mode
       '((prisma :url "https://github.com/victorhqc/tree-sitter-prisma"
                 :rev "v1.6.0"))))
   (map! :localleader
         :map prisma-mode-map
-        "f" #'prisma-format-buffer))
+        "f" #'lsp-format-buffer))

--- a/modules/lang/prisma/doctor.el
+++ b/modules/lang/prisma/doctor.el
@@ -1,0 +1,17 @@
+;;; lang/prisma/doctor.el -*- lexical-binding: t; -*-
+
+(assert! (or (not (modulep! +lsp))
+             (modulep! :tools lsp))
+         "This module requires (:tools lsp)")
+
+(assert! (or (not (modulep! +tree-sitter))
+             (modulep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
+(unless (executable-find "prisma")
+  (warn! "Couldn't find prisma CLI in your PATH."))
+
+(when (and (modulep! +lsp)
+           (modulep! :tools lsp))
+  (unless (executable-find "prisma-language-server")
+    (warn! "Couldn't find prisma-language-server. LSP will not work.")))

--- a/modules/lang/prisma/packages.el
+++ b/modules/lang/prisma/packages.el
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+;;; lang/prisma/packages.el
+
+(package! prisma-mode
+  :recipe (:host github :repo "pimeys/emacs-prisma-mode"
+           :files ("prisma-mode.el"))
+  :pin "f7744a995e84b8cf51265930ce18f6a6b26dade7")

--- a/modules/lang/prisma/packages.el
+++ b/modules/lang/prisma/packages.el
@@ -3,5 +3,5 @@
 
 (package! prisma-mode
   :recipe (:host github :repo "pimeys/emacs-prisma-mode"
-           :files ("prisma-mode.el"))
+           :files ("prisma-mode.el" "lsp-prisma.el"))
   :pin "f7744a995e84b8cf51265930ce18f6a6b26dade7")


### PR DESCRIPTION
Adds support for Prisma ORM schema files (`.prisma`) with:

- **Syntax highlighting** via `prisma-mode` (from pimeys/emacs-prisma-mode)
- **Tree-sitter** support via victorhqc/tree-sitter-prisma (with `+tree-sitter` flag)
- **LSP integration** via `prisma-language-server` from `@prisma/language-server` (with `+lsp` flag)
- **Format** via `prisma format`

Module flags: `+lsp`, `+tree-sitter`

Usage in `init.el`:

```elisp
(prisma +lsp)  ; or (prisma +lsp +tree-sitter)
```

**Note**: The `+lsp` flag requires the lsp-prisma client from https://github.com/emacs-lsp/lsp-mode/pull/5095 (pending review). Without it, syntax highlighting and tree-sitter still work.