### PR TITLE
feat(elixir): highlight Elixir code inside curly braces in HEEx

### DIFF
--- a/modules/lang/elixir/config.el
+++ b/modules/lang/elixir/config.el
@@ -65,6 +65,21 @@
   (set-indent-vars! 'elixir-mode 'elixir-smie-indent-basic))
 
 
+;; Add highlighting for Elixir code inside HEEx's curly braces
+(defun +elixir-ts-embed-elixir-in-heex-h ()
+  (when (treesit-ready-p 'heex)
+    (setq-local
+     treesit-range-settings
+     (append treesit-range-settings
+             (treesit-range-rules
+              :embed 'elixir
+              :host 'heex
+              :local t
+              '((expression (expression_value) @cap)
+                (directive (expression_value) @cap)
+                (directive (partial_expression_value) @cap)
+                (directive (ending_expression_value) @cap)))))))
+
 (use-package! elixir-ts-mode  ; 30.1+ only
   :when (modulep! +tree-sitter)
   :defer t
@@ -74,6 +89,7 @@
               :commit "d24cecee673c4c770f797bac6f87ae4b6d7ddec5")
       (heex :url "https://github.com/phoenixframework/tree-sitter-heex"
             :commit "b5a7cb5f74dc695a9ff5f04919f872ebc7a895e9")))
+  (add-hook 'elixir-ts-mode-hook #'+elixir-ts-embed-elixir-in-heex-h)
   :config
   (+elixir-common-config 'elixir-ts-mode))
 
@@ -82,3 +98,4 @@
   :when (modulep! +tree-sitter)
   :when (fboundp 'heex-ts-mode) ; 30.1+ only
   :mode "\\.[hl]?eex\\'")
+


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

This improves syntax highlighting for Elixir code inside HEEx templates inside Elixir code (in curly braces). Perhaps better to show as an image.

Currently:
<img width="920" height="625" alt="Screenshot_20260713_221324" src="https://github.com/user-attachments/assets/600a46ff-d9f7-4315-adff-55eb743812c6" />

After these changes:
<img width="842" height="615" alt="Screenshot_20260713_222511" src="https://github.com/user-attachments/assets/014425c3-fd27-40fd-acf6-ed3fb45ced45" />

The code is after the fix found and published in Elixir Forum: https://forum.elixirforum.com/t/help-with-elixir-ts-mode-in-doom-emacs-config/75892/6?u=katafrakt

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
