### PR TITLE
fix(markdown): drop deprecated --highlight-style

### DIFF
--- a/modules/lang/markdown/autoload.el
+++ b/modules/lang/markdown/autoload.el
@@ -66,8 +66,7 @@ Returns its exit code."
     (call-process-region beg end "pandoc" nil output-buffer nil
                          "-f" "markdown"
                          "-t" "html"
-                         "--mathjax"
-                         "--highlight-style=pygments")))
+                         "--mathjax")))
 
 ;;;###autoload
 (defun +markdown-compile-multimarkdown (beg end output-buffer)


### PR DESCRIPTION
pandoc 3.8 deprecated `--highlight-style` in favour of `--syntax-highlighting`, so newer pandoc prints:

>   Deprecated: --highlight-style. Use --syntax-highlighting instead.

`+markdown-compile-pandoc` passes a plain buffer as `call-process-region`'s `BUFFER` argument, which merges stderr into stdout, so this warning is injected into the rendered HTML instead of being discarded. Seen with pandoc 3.10.1 via `markdown-preview`.

Rather than gate the flag on pandoc <3.8 vs >=3.8, drop it altogether: pygments is already pandoc's default style, so output is unchanged and the command still works on every pandoc version.

Ref: https://github.com/jgm/pandoc/releases/tag/3.8
specifically
>   * Add a new command line option `--syntax-highlighting`; this takes
    the values `none`, `default`, `idiomatic`, a style name, or a path to a
    theme file. It replaces the `--no-highlighting`, `--highlighting-style`,
    and `--listings` options, which will still work but with a deprecation
    warning. (Albert Krewinkel)

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
