### PR TITLE
fix(yaml): borrow yaml-mode indent for treesitter

### DIFF
--- a/modules/lang/yaml/config.el
+++ b/modules/lang/yaml/config.el
@@ -13,5 +13,13 @@
   :init
   (set-tree-sitter! 'yaml-mode 'yaml-ts-mode 'yaml)
   :config
+  ;; HACK: `yaml-ts-mode' does not implements any indentation,
+  ;; leaving it on `indent-relative'. Borrow `yaml-mode's
+  ;; indenter, it is installed regardless by this module.
+  ;; See upstream GNU bug report: #77094
+  (add-hook 'yaml-ts-mode-hook
+            (defun +yaml-use-yaml-mode-indentation-h ()
+              (require 'yaml-mode)
+              (setq-local indent-line-function #'yaml-indent-line)))
   (when (modulep! +lsp)
     (add-hook 'yaml-ts-mode-local-vars-hook #'lsp! 'append)))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

`yaml-ts-mode` does not implement any lang-aware indentation, leading to inconsistent behaviour. This change simply borrows the `indent-line-function` from `yaml-mode`. 

This issue was reported to Emacs one year ago, so I thought it was disruptive enough to warrant an hack.

[Bug Report](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=77094)

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
