### PR TITLE
fix(popup): restore all popups set aside by save-popups!

### DIFF
--- a/modules/ui/popup/config.el
+++ b/modules/ui/popup/config.el
@@ -114,8 +114,11 @@ prevent the popup(s) from messing up the UI (or vice versa)."
           (+popup--inhibit-transient t)
           buffer-list-update-hook
           +popup--last)
-     (dolist (p popups)
-       (+popup/close p 'force))
+     (when popups
+       (+popup--remember popups)
+       (let (+popup--remember-last)
+         (dolist (p popups)
+           (+popup/close p 'force))))
      (unwind-protect
          (progn ,@body)
        (when popups


### PR DESCRIPTION
## Problem

`save-popups!` sets aside all visible popups, runs its body, then restores them. When two or more popups are visible, only one comes back; the rest are silently deleted.

Reproduction on current `main`:

1. Open two popup windows (any buffers matched by popup rules, in different slots).
2. Run any function advised with `+popup-save-a`, e.g. `M-x balance-windows`.
3. Only one popup remains.

A common way to hit this without calling `balance-windows` yourself: `evil-window-delete` calls `balance-windows` when `evil-auto-balance-windows` is non-nil (the default), so closing any window with `+workspace/close-window-or-workspace` or `evil-quit` while several popups are visible deletes one extra popup window.

## Cause

`save-popups!` closes each popup with `(+popup/close p 'force)` in a `dolist`. Each call runs `(+popup--remember (list window))`, and `+popup--remember` replaces `+popup--last` with `setq`. The second close overwrites the first popup's record, so the `+popup/restore` in the unwind form only restores the last popup closed.

## Fix

Remember all popups once, before closing them, and suppress the per-close remembering by binding `+popup--remember-last` to nil. This mirrors what `+popup/close-all` already does. Window state must be captured before deletion because `+popup--remember` calls `window-state-get` on live windows.

## Verification

Ran against a live session with an ERT test: display two popups (slots 8 and 9, `:quit nil :ttl nil`), run `(save-popups! (ignore))`, assert both buffers still have live windows. Fails on current `main` (first popup's window is nil after restore), passes with this patch. Also verified the `evil-window-delete` → `balance-windows` path interactively: with three popups visible, closing one no longer deletes a second one.