### PR TITLE
fix(popup): read modeline parameter from the buffer's popup window

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -282,7 +282,13 @@ Possible values for this parameter are:
 Any non-nil value besides the above will be used as the raw value for
 `mode-line-format'."
   (when (bound-and-true-p +popup-buffer-mode)
-    (let ((modeline (+popup-parameter 'modeline)))
+    ;; This runs from the buffer's `after-change-major-mode-hook', where
+    ;; the selected window is not necessarily the one displaying the
+    ;; buffer, so read the parameter from the buffer's popup window.
+    (let ((modeline (+popup-parameter
+                     'modeline
+                     (seq-find #'+popup-window-p
+                               (get-buffer-window-list nil nil t)))))
       (cond ((eq modeline 't))
             ((null modeline)
              (mode-line-invisible-mode +1))


### PR DESCRIPTION
## Problem

`+popup-set-modeline-on-enable-h` reads the `modeline` window parameter from the selected window (`+popup-parameter` defaults to `(selected-window)`). That is correct in the initial popup-display flow, where the popup window is selected when the hook runs. But `+popup-buffer-mode` also registers the hook in the buffer's permanent `after-change-major-mode-hook`, and a major mode change can happen while the selected window is some other window entirely.

When that happens, the hook reads the unrelated window's parameter, gets nil, and hides the popup buffer's modeline even though its popup rule specifies `:modeline t`.

Concrete trigger: agent-shell-viewport buffers flip between edit and view major modes programmatically. Every flip that occurs while another window is selected (async refresh, prefilled compose) hides the modeline; the next flip with the popup window selected restores it. The modeline appears to come and go at random.

## Fix

Read the parameter from the buffer's own popup window: `(seq-find #'+popup-window-p (get-buffer-window-list nil nil t))`. When no popup window shows the buffer, `+popup-parameter` falls back to the selected window, preserving the previous behavior.

## Reproduce

1. Display a buffer via a popup rule with `:modeline t`.
2. With a different window selected, run `(with-current-buffer popup-buf (fundamental-mode))` (any major mode change).
3. Without this patch the popup's modeline disappears; with it the modeline stays.