### PR TITLE
revert: fix(syntax): disable org-lint for now

### DIFF
--- a/modules/checkers/syntax/config.el
+++ b/modules/checkers/syntax/config.el
@@ -18,10 +18,6 @@
   :commands flycheck-list-errors flycheck-buffer
   :hook (doom-first-buffer . global-flycheck-mode)
   :config
-  ;; REVIEW: Remove when flycheck/flycheck#2161 is addressed or
-  ;;   flycheck/flycheck#2165 is merged.
-  (setq-default flycheck-disabled-checkers '(org-lint))
-
   (setq flycheck-emacs-lisp-load-path 'inherit)
 
   ;; Rerunning checks on every newline is a mote excessive.


### PR DESCRIPTION
The upstream issues have been fixed, and we have bumped (b4c0c50089e1) to a revision that incluces the fixes.

Amend: b4c0c50089e1
Ref: flycheck/flycheck#2161
Ref: flycheck/flycheck#2165
Revert: 3a6ad540c359

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.
