### PR TITLE
fix: change Dart tree-sitter grammar

### DIFF
--- a/modules/tools/tree-sitter/config.el
+++ b/modules/tools/tree-sitter/config.el
@@ -222,7 +222,7 @@
                  (cuda :url "https://github.com/tree-sitter-grammars/tree-sitter-cuda")
                  (css :url "https://github.com/tree-sitter/tree-sitter-css"
                       :rev ,(if (< (treesit-library-abi-version) 15) "v0.23.0" "v0.23.2"))
-                 (dart :url "https://github.com/ast-grep/tree-sitter-dart")
+                 (dart :url "https://github.com/UserNobody14/tree-sitter-dart")
                  (dockerfile :url "https://github.com/camdencheek/tree-sitter-dockerfile"
                              :commit "087daa20438a6cc01fa5e6fe6906d77c869d19fe")
                  (doxygen :url "https://github.com/tree-sitter-grammars/tree-sitter-doxygen"


### PR DESCRIPTION
Switches the Dart tree-sitter grammar to the upstream used by dart-ts-mode, adding Dart 3 support for when, sealed, and base and fixing treesit-query-error.

Fixes #62 

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
