### PR TITLE
fix(magit): don't reuse a dedicated window for magit buffers

### DIFF
--- a/modules/tools/magit/autoload.el
+++ b/modules/tools/magit/autoload.el
@@ -64,11 +64,15 @@
   "`display-buffer-alist' handler that opens BUFFER in a direction.
 
 This differs from `display-buffer-in-direction' in one way: it will try to use a
-window that already exists in that direction. It will split otherwise."
+window that already exists in that direction. It will split otherwise.
+
+Dedicated windows are never reused, since `switch-to-buffer' below cannot
+switch buffers in one; such a window is left alone and we split instead."
   (let ((direction (or (alist-get 'direction alist)
                        +magit-open-windows-in-direction))
         (origin-window (selected-window)))
-    (if-let* ((window (window-in-direction direction)))
+    (if-let* ((window (window-in-direction direction))
+              ((not (window-dedicated-p window))))
         (unless magit-display-buffer-noselect
           (select-window window))
       (if-let* ((window (and (not (one-window-p))
@@ -77,7 +81,8 @@ window that already exists in that direction. It will split otherwise."
                                 (`right 'left)
                                 (`left 'right)
                                 ((or `up `above) 'down)
-                                ((or `down `below) 'up))))))
+                                ((or `down `below) 'up)))))
+                ((not (window-dedicated-p window))))
         (unless magit-display-buffer-noselect
           (select-window window))
         (let ((window (split-window nil nil direction)))


### PR DESCRIPTION
Opening a commit from `magit-status` fails with `user-error: Cannot switch buffers in a dedicated window` whenever the window adjacent to magit in `+magit-open-windows-in-direction` is dedicated — Treemacs, or any terminal buffer in a dedicated window. Because the neighbour is chosen by geometry, moving point elsewhere first doesn't help.

`+magit--display-buffer-in-direction` reuses whatever `window-in-direction` returns without checking dedication. `select-window` on a dedicated window is legal, so the reuse branch succeeds, and the trailing `switch-to-buffer` signals because it acts on the now-selected window. `display-buffer`'s own dedicated-window handling never runs, since this handler bypasses it.

This skips dedicated windows in both reuse branches, letting them fall through to the existing `split-window` fallback — which splits the selected window, leaving the dedicated neighbour untouched.

Verified interactively against the reported layout (magit-status with a dedicated `eat` window immediately to its right): the revision buffer now opens in a fresh split and no dedicated window is disturbed.

Fixes #67
