### PR TITLE
fix(ruby): make ruby-mode-map bindings work in ruby-ts-mode 

### DIFF
--- a/modules/lang/ruby/config.el
+++ b/modules/lang/ruby/config.el
@@ -45,7 +45,8 @@
   (set-electric! 'ruby-ts-mode :words '("else" "end" "elsif"))
   (set-repl-handler! 'ruby-ts-mode #'inf-ruby)
   (when (modulep! +lsp)
-    (add-hook 'ruby-ts-mode-local-vars-hook #'lsp! 'append)))
+    (add-hook 'ruby-ts-mode-local-vars-hook #'lsp! 'append))
+  (set-keymap-parent ruby-ts-mode-map ruby-mode-map))
 
 (use-package! yard-mode
   :hook ruby-mode)


### PR DESCRIPTION
## Issue
Ruby’s default keymap is missing when using the `+treesitter` flag.

## Cause
`ruby-ts-mode-map` is derived from `prog-mode-map` and not `ruby-mode-map`, so it does not inherit the keymap.

## Fix
One line in the existing `ruby-ts-mode` `:config` block:

```elisp
(set-keymap-parent ruby-ts-mode-map ruby-mode-map)
```

## Disclaimers
### AI
I am not very confident using elisp, so I had help from AI to find the issue and confirm the fix was the correct way to handle it.

### Commit message
The [git conventions](https://doomemacs.org/d/git-conventions) link was broken when I tried to access it. Did my best to write a clean message. I can rewrite it and force-push if needed.

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [x] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.