### PR TITLE
feat(common-lisp): add +tree-sitter flag

### DIFF
--- a/modules/lang/common-lisp/README.org
+++ b/modules/lang/common-lisp/README.org
@@ -19,7 +19,9 @@ to run unmodified for a long time.
 /This module has no dedicated maintainers./ [[doom-contrib-maintainer:][Become a maintainer?]]
 
 ** Module flags
-/This module has no flags./
+- +tree-sitter ::
+  Leverages tree-sitter for better syntax highlighting and handling of ~FORMAT~
+  strings. Requires [[module::tools tree-sitter]].
 
 ** Packages
 - [[package:sly]]

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -205,14 +205,9 @@
   :defer t
   :hook (lisp-ts-mode . lisp-ts-format-support-mode)
   :init (set-tree-sitter! 'lisp-mode 'lisp-ts-mode
-          '((common-lisp
-             :url "https://codeberg.org/zshaftel/tree-sitter-cl-syntax"
-             :commit "dd2290d2a2480f4d865c57ed541dc714645c386b"
-             :source-dir "grammars/cl/src")
-            (cl-format
-             :url "https://codeberg.org/zshaftel/tree-sitter-cl-syntax"
-             :commit "dd2290d2a2480f4d865c57ed541dc714645c386b"
-             :source-dir "grammars/format/src")))
+          ;; lisp-ts-mode.el adds these to `treesit-language-source-alist', no
+          ;; need to duplicate those settings here
+          '(common-lisp cl-format))
   :config
   (setf (alist-get 'lisp-ts-mode font-lock-ignore)
         lisp-ts-mode-font-lock-ignore-keywords)

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -18,11 +18,11 @@
 
 (defun +common-lisp--define-keys (map)
   "Add the Common Lisp specific keybindings to MAP."
-  (map! (:map map
+  (map! (:map ,map
          :n "gb" #'sly-pop-find-definition-stack)
 
         (:localleader
-         :map map
+         :map ,map
          :desc "Sly"                       "'" #'sly
          :desc "Sly (ask)"                 ";" (cmd!! #'sly '-)
          :desc "Expand macro"              "m" #'macrostep-expand
@@ -179,7 +179,7 @@
          :n "gr" #'sly-recompile-xref
          :n "gR" #'sly-recompile-all-xrefs))
 
-  (+common-lisp--define-keys lisp-mode-map)
+  (+common-lisp--define-keys 'lisp-mode-map)
 
   (when (modulep! :editor evil +everywhere)
     (add-hook 'sly-mode-hook #'evil-normalize-keymaps)))
@@ -212,4 +212,4 @@
   (setf (alist-get 'lisp-ts-mode font-lock-ignore)
         lisp-ts-mode-font-lock-ignore-keywords)
   (setopt lisp-ts-mode-format-indent-tilde-relative 'end)
-  (+common-lisp--define-keys lisp-ts-mode-map))
+  (+common-lisp--define-keys 'lisp-ts-mode-map))

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -16,6 +16,76 @@
 (defvar inferior-lisp-program "sbcl")
 
 
+(defun +common-lisp--define-keys (map)
+  "Add the Common Lisp specific keybindings to MAP."
+  (map! (:map map
+         :n "gb" #'sly-pop-find-definition-stack)
+
+        (:localleader
+         :map map
+         :desc "Sly"                       "'" #'sly
+         :desc "Sly (ask)"                 ";" (cmd!! #'sly '-)
+         :desc "Expand macro"              "m" #'macrostep-expand
+         :desc "Find local Quicklisp file" "f" #'+lisp/find-file-in-quicklisp
+         (:prefix ("c" . "compile")
+          :desc "Compile file"          "c" #'sly-compile-file
+          :desc "Compile/load file"     "C" #'sly-compile-and-load-file
+          :desc "Compile toplevel form" "f" #'sly-compile-defun
+          :desc "Load file"             "l" #'sly-load-file
+          :desc "Remove notes"          "n" #'sly-remove-notes
+          :desc "Compile region"        "r" #'sly-compile-region)
+         (:prefix ("e" . "evaluate")
+          :desc "Evaluate buffer"        "b" #'sly-eval-buffer
+          :desc "Evaluate defun"         "d" #'sly-overlay-eval-defun
+          :desc "Evaluate last"          "e" #'sly-eval-last-expression
+          :desc "Evaluate/print last"    "E" #'sly-eval-print-last-expression
+          :desc "Evaluate defun (async)" "f" #'sly-eval-defun
+          :desc "Undefine function"      "F" #'sly-undefine-function
+          :desc "Evaluate region"        "r" #'sly-eval-region)
+         (:prefix ("g" . "goto")
+          :desc "Go back"              "b" #'sly-pop-find-definition-stack
+          :desc "Go to"                "d" #'sly-edit-definition
+          :desc "Go to (other window)" "D" #'sly-edit-definition-other-window
+          :desc "Next note"            "n" #'sly-next-note
+          :desc "Previous note"        "N" #'sly-previous-note
+          :desc "Next sticker"         "s" #'sly-stickers-next-sticker
+          :desc "Previous sticker"     "S" #'sly-stickers-prev-sticker)
+         (:prefix ("h" . "help")
+          :desc "Who calls"               "<" #'sly-who-calls
+          :desc "Calls who"               ">" #'sly-calls-who
+          :desc "Lookup format directive" "~" #'hyperspec-lookup-format
+          :desc "Lookup reader macro"     "#" #'hyperspec-lookup-reader-macro
+          :desc "Apropos"                 "a" #'sly-apropos
+          :desc "Who binds"               "b" #'sly-who-binds
+          :desc "Disassemble symbol"      "d" #'sly-disassemble-symbol
+          :desc "Describe symbol"         "h" #'sly-describe-symbol
+          :desc "HyperSpec lookup"        "H" #'sly-hyperspec-lookup
+          :desc "Who macro-expands"       "m" #'sly-who-macroexpands
+          :desc "Apropos package"         "p" #'sly-apropos-package
+          :desc "Who references"          "r" #'sly-who-references
+          :desc "Who specializes"         "s" #'sly-who-specializes
+          :desc "Who sets"                "S" #'sly-who-sets)
+         (:prefix ("r" . "repl")
+          :desc "Clear REPL"         "c" #'sly-mrepl-clear-repl
+          :desc "Load System"        "l" #'sly-asdf-load-system
+          :desc "Quit connection"    "q" #'sly-quit-lisp
+          :desc "Restart connection" "r" #'sly-restart-inferior-lisp
+          :desc "Reload Project"     "R" #'+lisp/reload-project
+          :desc "Sync REPL"          "s" #'sly-mrepl-sync)
+         (:prefix ("s" . "stickers")
+          :desc "Toggle breaking stickers" "b" #'sly-stickers-toggle-break-on-stickers
+          :desc "Clear defun stickers"     "c" #'sly-stickers-clear-defun-stickers
+          :desc "Clear buffer stickers"    "C" #'sly-stickers-clear-buffer-stickers
+          :desc "Fetch stickers"           "f" #'sly-stickers-fetch
+          :desc "Replay stickers"          "r" #'sly-stickers-replay
+          :desc "Add/remove sticker"       "s" #'sly-stickers-dwim)
+         (:prefix ("t" . "test")
+          :desc "Test System" "s" #'sly-asdf-test-system)
+         (:prefix ("T" . "trace")
+          :desc "Toggle"         "t" #'sly-toggle-trace-fdefinition
+          :desc "Toggle (fancy)" "T" #'sly-toggle-fancy-trace
+          :desc "Untrace all"    "u" #'sly-untrace-all))))
+
 (use-package! sly
   :hook ((lisp-ts-mode lisp-mode-local-vars) . sly-editing-mode)
   :init
@@ -107,74 +177,9 @@
          :n "K"  #'sly-inspector-describe-inspectee)
         (:map sly-xref-mode-map
          :n "gr" #'sly-recompile-xref
-         :n "gR" #'sly-recompile-all-xrefs)
-        (:map lisp-mode-map
-         :n "gb" #'sly-pop-find-definition-stack)
+         :n "gR" #'sly-recompile-all-xrefs))
 
-        (:localleader
-         :map lisp-mode-map
-         :desc "Sly"                       "'" #'sly
-         :desc "Sly (ask)"                 ";" (cmd!! #'sly '-)
-         :desc "Expand macro"              "m" #'macrostep-expand
-         :desc "Find local Quicklisp file" "f" #'+lisp/find-file-in-quicklisp
-         (:prefix ("c" . "compile")
-          :desc "Compile file"          "c" #'sly-compile-file
-          :desc "Compile/load file"     "C" #'sly-compile-and-load-file
-          :desc "Compile toplevel form" "f" #'sly-compile-defun
-          :desc "Load file"             "l" #'sly-load-file
-          :desc "Remove notes"          "n" #'sly-remove-notes
-          :desc "Compile region"        "r" #'sly-compile-region)
-         (:prefix ("e" . "evaluate")
-          :desc "Evaluate buffer"        "b" #'sly-eval-buffer
-          :desc "Evaluate defun"         "d" #'sly-overlay-eval-defun
-          :desc "Evaluate last"          "e" #'sly-eval-last-expression
-          :desc "Evaluate/print last"    "E" #'sly-eval-print-last-expression
-          :desc "Evaluate defun (async)" "f" #'sly-eval-defun
-          :desc "Undefine function"      "F" #'sly-undefine-function
-          :desc "Evaluate region"        "r" #'sly-eval-region)
-         (:prefix ("g" . "goto")
-          :desc "Go back"              "b" #'sly-pop-find-definition-stack
-          :desc "Go to"                "d" #'sly-edit-definition
-          :desc "Go to (other window)" "D" #'sly-edit-definition-other-window
-          :desc "Next note"            "n" #'sly-next-note
-          :desc "Previous note"        "N" #'sly-previous-note
-          :desc "Next sticker"         "s" #'sly-stickers-next-sticker
-          :desc "Previous sticker"     "S" #'sly-stickers-prev-sticker)
-         (:prefix ("h" . "help")
-          :desc "Who calls"               "<" #'sly-who-calls
-          :desc "Calls who"               ">" #'sly-calls-who
-          :desc "Lookup format directive" "~" #'hyperspec-lookup-format
-          :desc "Lookup reader macro"     "#" #'hyperspec-lookup-reader-macro
-          :desc "Apropos"                 "a" #'sly-apropos
-          :desc "Who binds"               "b" #'sly-who-binds
-          :desc "Disassemble symbol"      "d" #'sly-disassemble-symbol
-          :desc "Describe symbol"         "h" #'sly-describe-symbol
-          :desc "HyperSpec lookup"        "H" #'sly-hyperspec-lookup
-          :desc "Who macro-expands"       "m" #'sly-who-macroexpands
-          :desc "Apropos package"         "p" #'sly-apropos-package
-          :desc "Who references"          "r" #'sly-who-references
-          :desc "Who specializes"         "s" #'sly-who-specializes
-          :desc "Who sets"                "S" #'sly-who-sets)
-         (:prefix ("r" . "repl")
-          :desc "Clear REPL"         "c" #'sly-mrepl-clear-repl
-          :desc "Load System"        "l" #'sly-asdf-load-system
-          :desc "Quit connection"    "q" #'sly-quit-lisp
-          :desc "Restart connection" "r" #'sly-restart-inferior-lisp
-          :desc "Reload Project"     "R" #'+lisp/reload-project
-          :desc "Sync REPL"          "s" #'sly-mrepl-sync)
-         (:prefix ("s" . "stickers")
-          :desc "Toggle breaking stickers" "b" #'sly-stickers-toggle-break-on-stickers
-          :desc "Clear defun stickers"     "c" #'sly-stickers-clear-defun-stickers
-          :desc "Clear buffer stickers"    "C" #'sly-stickers-clear-buffer-stickers
-          :desc "Fetch stickers"           "f" #'sly-stickers-fetch
-          :desc "Replay stickers"          "r" #'sly-stickers-replay
-          :desc "Add/remove sticker"       "s" #'sly-stickers-dwim)
-         (:prefix ("t" . "test")
-          :desc "Test System" "s" #'sly-asdf-test-system)
-         (:prefix ("T" . "trace")
-          :desc "Toggle"         "t" #'sly-toggle-trace-fdefinition
-          :desc "Toggle (fancy)" "T" #'sly-toggle-fancy-trace
-          :desc "Untrace all"    "u" #'sly-untrace-all)))
+  (+common-lisp--define-keys lisp-mode-map)
 
   (when (modulep! :editor evil +everywhere)
     (add-hook 'sly-mode-hook #'evil-normalize-keymaps)))
@@ -211,4 +216,5 @@
   :config
   (setf (alist-get 'lisp-ts-mode font-lock-ignore)
         lisp-ts-mode-font-lock-ignore-keywords)
-  (setopt lisp-ts-mode-format-indent-tilde-relative 'end))
+  (setopt lisp-ts-mode-format-indent-tilde-relative 'end)
+  (+common-lisp--define-keys lisp-ts-mode-map))

--- a/modules/lang/common-lisp/config.el
+++ b/modules/lang/common-lisp/config.el
@@ -17,7 +17,7 @@
 
 
 (use-package! sly
-  :hook (lisp-mode-local-vars . sly-editing-mode)
+  :hook ((lisp-ts-mode lisp-mode-local-vars) . sly-editing-mode)
   :init
   ;; I moved this hook to `lisp-mode-local-vars', so it only affects
   ;; `lisp-mode', and not every other derived lisp mode (like `fennel-mode').
@@ -26,11 +26,12 @@
   (after! (:or emacs sly)
     (remove-hook 'lisp-mode-hook #'sly-editing-mode))
 
-  (after! lisp-mode
-    (set-repl-handler! 'lisp-mode #'+lisp/open-repl)
-    (set-eval-handler! 'lisp-mode #'sly-eval-region)
-    (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer :modes '(lisp-mode))
-    (set-lookup-handlers! 'lisp-mode
+  (after! (:or lisp-mode lisp-ts-mode)
+    (set-repl-handler! '(lisp-mode lisp-ts-mode) #'+lisp/open-repl)
+    (set-eval-handler! '(lisp-mode lisp-ts-mode) #'sly-eval-region)
+    (set-formatter! 'lisp-indent #'apheleia-indent-lisp-buffer
+      :modes '(lisp-mode lisp-ts-mode))
+    (set-lookup-handlers! '(lisp-mode lisp-ts-mode)
       :definition #'sly-edit-definition
       :documentation #'sly-describe-symbol))
 
@@ -193,3 +194,21 @@
   :defer t
   :init
   (add-to-list 'sly-contribs 'sly-stepper))
+
+(use-package! lisp-ts-mode
+  :when (modulep! +tree-sitter)
+  :defer t
+  :hook (lisp-ts-mode . lisp-ts-format-support-mode)
+  :init (set-tree-sitter! 'lisp-mode 'lisp-ts-mode
+          '((common-lisp
+             :url "https://codeberg.org/zshaftel/tree-sitter-cl-syntax"
+             :commit "dd2290d2a2480f4d865c57ed541dc714645c386b"
+             :source-dir "grammars/cl/src")
+            (cl-format
+             :url "https://codeberg.org/zshaftel/tree-sitter-cl-syntax"
+             :commit "dd2290d2a2480f4d865c57ed541dc714645c386b"
+             :source-dir "grammars/format/src")))
+  :config
+  (setf (alist-get 'lisp-ts-mode font-lock-ignore)
+        lisp-ts-mode-font-lock-ignore-keywords)
+  (setopt lisp-ts-mode-format-indent-tilde-relative 'end))

--- a/modules/lang/common-lisp/doctor.el
+++ b/modules/lang/common-lisp/doctor.el
@@ -7,3 +7,11 @@
                   (split-string inferior-lisp-program))))
     (warn! "Couldn't find your `inferior-lisp-program' (%s). Is it installed?"
            inferior-lisp-program)))
+
+(assert! (or (not (modulep! +tree-sitter))
+             (modulep! :tools tree-sitter))
+         "This module requires (:tools tree-sitter)")
+
+(and (modulep! +tree-sitter)
+     (< (treesit-library-abi-version) 15)
+     (warn! "Tree-sitter library version is too old for the Common Lisp grammar."))

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -13,4 +13,5 @@
 (when (and (modulep! +tree-sitter)
            (treesit-available-p)
            (version<= "30.2" emacs-version))
-  (package! lisp-ts-mode :pin "d42a20f33c46d8eaa653440e134c0aa954dbbe98"))
+  (package! lisp-ts-mode :recipe (:host codeberg :repo "zshaftel/lisp-ts-mode")
+                         :pin "d42a20f33c46d8eaa653440e134c0aa954dbbe98"))

--- a/modules/lang/common-lisp/packages.el
+++ b/modules/lang/common-lisp/packages.el
@@ -9,3 +9,8 @@
   (package! sly-macrostep :pin "5113e4e926cd752b1d0bcc1508b3ebad5def5fad")
   (package! sly-repl-ansi-color :pin "b9cd52d1cf927bf7e08582d46ab0bcf1d4fb5048")
   (package! sly-overlay :pin "345b554ad005421b447b2e64c34314ee79f5f8b9"))
+
+(when (and (modulep! +tree-sitter)
+           (treesit-available-p)
+           (version<= "30.2" emacs-version))
+  (package! lisp-ts-mode :pin "d42a20f33c46d8eaa653440e134c0aa954dbbe98"))


### PR DESCRIPTION
<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

This just adds a  `+tree-sitter` flag to the common-lisp module to replace `lisp-mode` with [`lisp-ts-mode`](https://codeberg.org/zshaftel/lisp-ts-mode). I haven't used Doom for a couple years so I haven't tested this nor am I sure it conforms to conventions. I used the Haskell module as a reference.

I added `lisp-ts-mode` to the various `set-*!` things in the `sly` `use-package!` form, and added `sly-editing-mode` to `lisp-ts-mode-hook` since it doesn't run any usual lisp-mode hooks. I factored all the `lisp-mode-map` keybindings into a separate function so we can do the same thing on `lisp-ts-mode-map` (not sure if this is the preferred way to do that). There's some simple configuration in a `lisp-ts-mode` `use-package!` block, I updated the README and added some diagnostics to doctor.el. 

I used `set-tree-sitter!` in this patch but I'm not sure that is a good idea for this mode. lisp-ts-mode.el doesn't touch `auto-mode-alist`, it adds `lisp-mode` as a derived parent, and adds the proper grammar entries to `treesit-language-source-alist`. `(add-to-list 'major-mode-remap-alist '(lisp-mode . lisp-ts-mode))` is what I recommend.

-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ ] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
   (not sure, the URL isn't working)
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [X] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->