### PR TITLE
docs(mu4e): fix stale mu4e-alert notification docs

### DIFF
--- a/modules/email/mu4e/README.org
+++ b/modules/email/mu4e/README.org
@@ -15,8 +15,7 @@ This module makes Emacs an email client, using [[https://www.djcbsoftware.nl/cod
 - [[package:org-msg]] integration with [[module:+org]], which can be toggled per-message, with revamped
   style and an accent color.
 - Gmail integrations with the [[module:+gmail]] flag.
-- Email notifications with [[pkg:mu4e-alert]], and (on Linux) a customised notification
-  style.
+- Email notifications, using mu4e's built-in notification support.
 
 #+begin_quote aside
 I want to live in Emacs, but as we all know, living is incomplete without email.
@@ -337,13 +336,15 @@ compose or reply command ([[kbd:][SPC u]] with [[pkg:evil]], [[kbd:][C-u]] other
 The accent color that Doom uses can be customised by setting
 ~+org-msg-accent-color~ to a CSS color string.
 
-** mu4e-alert
-This provides notifications through the [[https://github.com/jwiegley/alert][alert]] library.
+** Notifications
+New-mail notifications are provided by mu4e itself (since mu4e 1.10), and this
+module enables them.
 
 If you don't like this use:
 #+begin_src emacs-lisp
-;; add to $DOOMDIR/packages.el
-(package! mu4e-alert :disable t)
+;; add to $DOOMDIR/config.el
+(after! mu4e
+  (setq mu4e-notification-support nil))
 #+end_src
 
 ** Enabling automatic email fetching


### PR DESCRIPTION
mu4e-alert was dropped in favor of mu4e's own notification support.

mu4e README still documents new-mail notifications as coming from mu4e-alert and the alert
  (https://github.com/jwiegley/alert) library.

mu4e grew its own notification support and Doom switched over to it, but the README was never fully updated.

Amend: eebae51768cf

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
