### PR TITLE
bump: doom-modeline

### DIFF
--- a/modules/ui/modeline/packages.el
+++ b/modules/ui/modeline/packages.el
@@ -2,7 +2,7 @@
 ;;; ui/modeline/packages.el
 
 (unless (modulep! +light)
-  (package! doom-modeline :pin "6f911e982bdf5518f8416b15a3e845909d219f59"))
+  (package! doom-modeline :pin "adbd6325be5f84eafbc85efb5685452a5ba489bf"))
 (package! anzu :pin "21cb5ab2295614372cb9f1a21429381e49a6255f")
 (when (modulep! :editor evil)
   (package! evil-anzu :pin "7309650425797420944075c9c1556c7c1ff960b3"))


### PR DESCRIPTION
seagle0128/doom-modeline@6f911e982bdf -> seagle0128/doom-modeline@adbd6325be5f

Pull in the fix for "Unable to find icon with name 'nf-cod-worktree' in icon set 'devicon'" in a git worktree (including git submodules like Doom's `sources/doom+`).

<!-- ⚠️ Please do not ignore this template! -->

<!--
  Summarize what you've changed and why. Include references to related
  issues/PRs. If changes are visual, include before and after screenshots
  please!
-->

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This PR contains AI-generated work.
- [ ] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once approved by a maintainer, you don't have to do anything more. It will
     be merged eventually!
   - If your PR is converted to a Draft, it means we approve of the idea, but
     more work here or elsewhere is needed, please be patient.
   - If you decide to close your PR, please let us know why you did so.

-->
